### PR TITLE
pythran 0.10.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,6 +22,7 @@ build:
     # pythran-win32.cfg already exists and has [compiler].include_dirs; we replace it on the fly;
     # conda will detect the written environment-path and replace it as appropriate for user installs;
     # note that we need r'...' for this due to paths like D:\bld\... where python would interpret \b.
+    # Seeking to 0 and overwriting without truncating only works, because the file is now longer than before.
     - "python -c \"with open('pythran\\pythran-win32.cfg', 'r+') as s: a=s.read(); s.seek(0); s.write(a.replace('include_dirs=', r'include_dirs=%PREFIX%/Library/include'))\""  # [win]
     # sanity check to ensure this is set correctly
     - type pythran\pythran-win32.cfg  # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 9dac8e1d50f33d4676003e350b1f0c878ce113e6f907920e92dc103352cac5bf
 
 build:
-  number: 3
+  number: 0
   script:
     # prevent d1trimfile option being added which clang-cl does not understand.
     # d1trimfile option is added by a patch and disabled by unsetting SRC_DIR

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,8 +6,8 @@ package:
 
 source:
   url: https://pypi.io/packages/source/p/pythran/pythran-{{ version }}.tar.gz
-  sha256: c4853430e99dc382b8ed11e6eed3a196a571b2f311db4be4cf7b28d6f6866c54
-
+  sha256: 9dac8e1d50f33d4676003e350b1f0c878ce113e6f907920e92dc103352cac5bf
+  
 build:
   number: 0
   script:
@@ -46,10 +46,10 @@ requirements:
     - xsimd >=7.6
 
 test:
-  requires:                           # [osx]
+  requires:
+    - pip
     # default to testing openblas
     - openblas-devel {{ openblas }}   # [osx]
-    - pip
   files:
     - dprod.py
     - simple_numexpr.py

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/p/pythran/pythran-{{ version }}.tar.gz
-  sha256: 9dac8e1d50f33d4676003e350b1f0c878ce113e6f907920e92dc103352cac5bf
+  sha256: c4853430e99dc382b8ed11e6eed3a196a571b2f311db4be4cf7b28d6f6866c54
 
 build:
   number: 0
@@ -49,12 +49,10 @@ test:
   requires:                           # [osx]
     # default to testing openblas
     - openblas-devel {{ openblas }}   # [osx]
-    - pip
   files:
     - dprod.py
     - simple_numexpr.py
   commands:
-    - pip check
     - set "SRC_DIR="  # [win]
     - pythran -v dprod.py
     - python -c "import dprod"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,8 +15,16 @@ build:
     # d1trimfile option is added by a patch and disabled by unsetting SRC_DIR
     # https://github.com/conda-forge/python-feedstock/blob/e7ea437a819f8f06dcbc3769f6e46dc026070c44/recipe/patches/0021-Add-d1trimfile-SRC_DIR-to-make-pdbs-more-relocatable.patch
     - set "SRC_DIR="   # [win]
+    # unvendor xsimd; use version packaged by conda
     - {{ PYTHON }} -c "import os, shutil; shutil.rmtree(os.path.join('pythran', 'xsimd'))"
     - "{{ PYTHON }} -c \"with open('setup.cfg', 'w') as s: s.write('[build_py]\\nno_xsimd=True')\""  # [not win]
+    # on windows, pythran wrongly sets %PREFIX\include instead of %PREFIX%\Library\include;
+    # pythran-win32.cfg already exists and has [compiler].include_dirs; we replace it on the fly;
+    # conda will detect the written environment-path and replace it as appropriate for user installs;
+    # note that we need r'...' for this due to paths like D:\bld\... where python would interpret \b.
+    - "python -c \"with open('pythran\\pythran-win32.cfg', 'r+') as s: a=s.read(); s.seek(0); s.write(a.replace('include_dirs=', r'include_dirs=%PREFIX%/Library/include'))\""  # [win]
+    # sanity check to ensure this is set correctly
+    - type pythran\pythran-win32.cfg  # [win]
     - {{ PYTHON }} -m pip install . --no-deps -vv
   entry_points:
     - pythran = pythran.run:run
@@ -40,10 +48,10 @@ requirements:
     - clangxx                # [win]
     - python
     - {{ pin_compatible('numpy') }}
-    - gast >=0.5
+    - gast >=0.5.0,<0.6.0
     - ply >=3.4
-    - beniget >=0.4
-    - xsimd >=7.6
+    - beniget >=0.4.0,<0.5.0
+    - xsimd >=7.6,<7.7
 
 test:
   requires:
@@ -55,6 +63,9 @@ test:
     - simple_numexpr.py
   commands:
     - pip check
+    - export CBS="-isysroot $(xcrun --show-sdk-path)" # [osx]
+    - export CFLAGS="${CFLAGS} ${CBS}"  # [osx]
+    - export CXXFLAGS="${CXXFLAGS} ${CBS}"  # [osx]
     - set "SRC_DIR="  # [win]
     - pythran -v dprod.py
     - python -c "import dprod"
@@ -71,7 +82,7 @@ test:
     - pythran.types
 
 about:
-  home: http://github.com/serge-sans-paille/pythran
+  home: https://github.com/serge-sans-paille/pythran
   license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -49,10 +49,12 @@ test:
   requires:                           # [osx]
     # default to testing openblas
     - openblas-devel {{ openblas }}   # [osx]
+    - pip
   files:
     - dprod.py
     - simple_numexpr.py
   commands:
+    - pip check
     - set "SRC_DIR="  # [win]
     - pythran -v dprod.py
     - python -c "import dprod"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,10 +40,10 @@ requirements:
     - clangxx                # [win]
     - python
     - {{ pin_compatible('numpy') }}
-    - gast 0.5.*
+    - gast >=0.5
     - ply >=3.4
-    - beniget 0.4.*
-    - xsimd 7.6.*
+    - beniget >=0.4
+    - xsimd >=7.6
 
 test:
   requires:                           # [osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.9.11" %}
+{% set version = "0.10.0" %}
 
 package:
   name: pythran
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/p/pythran/pythran-{{ version }}.tar.gz
-  sha256: a317f91e2aade9f6550dc3bf40b5caeb45b7e012daf27e2b3e4ad928edb01667
+  sha256: 9dac8e1d50f33d4676003e350b1f0c878ce113e6f907920e92dc103352cac5bf
 
 build:
   number: 3
@@ -40,13 +40,10 @@ requirements:
     - clangxx                # [win]
     - python
     - {{ pin_compatible('numpy') }}
-    - decorator
-    - gast 0.4
-    - networkx >=2
+    - gast 0.5.*
     - ply >=3.4
-    - six
-    - beniget 0.3
-    - xsimd
+    - beniget 0.4.*
+    - xsimd 7.6.*
 
 test:
   requires:                           # [osx]


### PR DESCRIPTION
`scipy 1.8.1` requires `pythran >=0.10.0,<0.11.0`

Update pythran to 0.10.0

Bug Tracker: new open issues https://github.com/serge-sans-paille/pythran/issues
Github releases:  https://github.com/serge-sans-paille/pythran/releases
Upstream license:  License file:  https://github.com/serge-sans-paille/pythran/blob/master/LICENSE
Upstream Changelog: https://github.com/serge-sans-paille/pythran/blob/master/Changelog
Requirements: 
- https://github.com/serge-sans-paille/pythran/blob/0.10.0/requirements.txt
- https://github.com/serge-sans-paille/pythran/blob/0.10.0/setup.py

The package pythran is mentioned inside the packages:
networkx | scipy |

Actions:
1. Remove `networkx`, `decorator`, and `six` from the run section, see https://github.com/serge-sans-paille/pythran/commit/462ab86b4a64b3f0755d2cb377ae9c0462f2f321#diff-4d7c51b1efe9043e44439a949dfd92e5827321b34082903477fd04876edb7552
2. Reset the build number to `0`
3. Add scripts
4. Fix pinning for `gast`, `beniget`, `xsmid`
5. Add `pip check`
6. Fix home url with HTTPS

Result:
- all-succeeded