### PR TITLE
update `pythran` to version `0.12.0`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.11.0" %}
+{% set version = "0.12.0" %}
 
 package:
   name: pythran
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/p/pythran/pythran-{{ version }}.tar.gz
-  sha256: 0b2cba712e09f7630879dff69f268460bfe34a6d6000451b47d598558a92a875
+  sha256: eff3dd0d3eebe57372f0d14f82985525e9bcdfb5b1d1010e1932cf9207060f9f
   
 build:
   number: 0
@@ -52,7 +52,7 @@ requirements:
     - gast >=0.5.0,<0.6.0
     - ply >=3.4
     - beniget >=0.4.0,<0.5.0
-    - xsimd >=8.0.5,<8.1
+    - xsimd >=8.0.5
 
 test:
   requires:


### PR DESCRIPTION

`pythran` version `0.12.0`
1. - [X] Check the upstream
    https://github.com/serge-sans-paille/pythran/tree/0.12.0
2. - [X] Check the pinnings
3. - [X] Check the changelogs
    https://github.com/serge-sans-paille/pythran/blob/0.12.0/Changelog
4. - [X] Additional research
    https://github.com/conda-forge/pythran-feedstock/issues
    
There is currently `1 Open` issue with `pythran`, the issue seems to be occur when older versions of `gast` are used, so we must keep an eye onn the package just in case.

5. - [X] Verify the `dev_url`
    https://github.com/serge-sans-paille/pythran
6. - [X] Verify the `doc_url`
    https://pythran.readthedocs.io/
7. - [X] License is `spdx` compliant
    BSD-3-Clause
8. - [X] License family is present
    BSD
9. - [X] Verify that the `build_number` is correct
10. - [X] Verify if the package needs `setuptools`
    setuptools
11. - [X] Verify if the package needs `wheel`
    wheel
12. - [X] `pip` in the test section
13. - [X] Veriy the test section
14. - [X] Verify if the package is `architecture specific` or `Noarch`
15. - [X] Verify that private modules are not mentioned on the recipe For example: (_private_module)
 
Results:
- 
 
 
Based on the research findings and the results we can conclude
that it should be ok to update `pythran` to version `0.12.0`
