### PR TITLE
update to 0.15.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - https://staging.continuum.io/prefect/fs/xsimd-feedstock/pr9/3eeb313

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/xsimd-feedstock/pr9/3eeb313

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -57,7 +57,7 @@ test:
   requires:
     - pip
     # default to testing openblas
-    - openblas-devel {{ openblas }}   # [osx]
+    - openblas-devel {{ openblas }}   # [linux or osx]
     - {{ compiler('c') }}  # [osx]
   files:
     - dprod.py

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,6 +50,7 @@ requirements:
     - gast >=0.5.0,<0.6.0
     - ply >=3.4
     - beniget >=0.4.0,<0.5.0
+    - setuptools # used in pythran.dist
     - xsimd 12.1.1
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,7 +39,6 @@ requirements:
   host:
     - python
     - pip
-    - numpy
     - setuptools
     - wheel
   run:
@@ -47,7 +46,7 @@ requirements:
     - clang                  # [win]
     - clangxx                # [win]
     - python
-    - {{ pin_compatible('numpy') }}
+    - numpy
     - gast >=0.5.0,<0.6.0
     - ply >=3.4
     - beniget >=0.4.0,<0.5.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.13.1" %}
+{% set version = "0.15.0" %}
 
 package:
   name: pythran
@@ -6,10 +6,11 @@ package:
 
 source:
   url: https://pypi.io/packages/source/p/pythran/pythran-{{ version }}.tar.gz
-  sha256: 8aad08162f010e5425a7b254dd68d83311b430bb29f9252dce2eff3ba39497dd
+  sha256: f9bc61bcb96df2cd4b578abc5a62dfb3fbb0b0ef02c264513dfb615c5f87871c
   
 build:
   number: 0
+  skip: true # [py<37]
   script:
     # prevent d1trimfile option being added which clang-cl does not understand.
     # d1trimfile option is added by a patch and disabled by unsetting SRC_DIR
@@ -17,7 +18,6 @@ build:
     - set "SRC_DIR="   # [win]
     # unvendor xsimd; use version packaged by conda
     - {{ PYTHON }} -c "import os, shutil; shutil.rmtree(os.path.join('pythran', 'xsimd'))"
-    - "{{ PYTHON }} -c \"with open('setup.cfg', 'w') as s: s.write('[build_py]\\nno_xsimd=True')\""  # [not win]
     # on windows, pythran wrongly sets %PREFIX\include instead of %PREFIX%\Library\include;
     # pythran-win32.cfg already exists and has [compiler].include_dirs; we replace it on the fly;
     # conda will detect the written environment-path and replace it as appropriate for user installs;

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,7 +50,7 @@ requirements:
     - gast >=0.5.0,<0.6.0
     - ply >=3.4
     - beniget >=0.4.0,<0.5.0
-    - xsimd 11.0.0
+    - xsimd 12.1.1
 
 test:
   requires:


### PR DESCRIPTION
Changes:
- update to 0.15.0
- update xsimd https://github.com/AnacondaRecipes/xsimd-feedstock/pull/9 to 12.1.1 with patch to match commit pinned in pythran.
- run tests against openblas on linux-64 - due to an issue locating mkl-sdl

https://github.com/serge-sans-paille/pythran/tree/0.15.0