### PR TITLE
update to 0.16.1

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -3,4 +3,6 @@ build_env_vars:
 
 channels:
   - https://staging.continuum.io/prefect/fs/clangdev-feedstock/pr4/0cf84db
+  - https://staging.continuum.io/prefect/fs/mkl_fft-feedstock/pr10/3c5014b
+  - https://staging.continuum.io/prefect/fs/mkl_random-feedstock/pr8/77506cb
   - https://staging.continuum.io/prefect/fs/numpy-feedstock/pr95/a5aec10

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,6 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313 : yes
+
+channels:
+  - https://staging.continuum.io/prefect/fs/clangdev-feedstock/pr4/0cf84db
+  - https://staging.continuum.io/prefect/fs/numpy-feedstock/pr95/a5aec10

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,8 +1,2 @@
 build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY313 : yes
-
-channels:
-  - https://staging.continuum.io/prefect/fs/clangdev-feedstock/pr4/0cf84db
-  - https://staging.continuum.io/prefect/fs/mkl_fft-feedstock/pr10/3c5014b
-  - https://staging.continuum.io/prefect/fs/mkl_random-feedstock/pr8/77506cb
-  - https://staging.continuum.io/prefect/fs/numpy-feedstock/pr95/a5aec10

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -48,7 +48,7 @@ requirements:
     - gast >=0.5.0,<0.6.0
     - ply >=3.4
     - beniget >=0.4.0,<0.5.0
-    - setuptools # used in pythran.dist
+    - setuptools <74 # used in pythran.dist. distutils.msvccompiler removed in recent setuptools
 
 test:
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,6 +16,9 @@ build:
     # d1trimfile option is added by a patch and disabled by unsetting SRC_DIR
     # https://github.com/conda-forge/python-feedstock/blob/e7ea437a819f8f06dcbc3769f6e46dc026070c44/recipe/patches/0021-Add-d1trimfile-SRC_DIR-to-make-pdbs-more-relocatable.patch
     - set "SRC_DIR="   # [win]
+    # Note that we leave xsimd vendored-in, because pythran is the only package that uses xsimd, 
+    # with the same license, and this means we have to maintain only one package rather than two.
+    # Also, it only vendors it in in certain versions, not all.
     # Set compilers to clang-cl
     - set "CC=clang-cl.exe"  # [win]
     - set "CXX=clang-cl.exe" # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.15.0" %}
+{% set version = "0.16.1" %}
 
 package:
   name: pythran
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/p/pythran/pythran-{{ version }}.tar.gz
-  sha256: f9bc61bcb96df2cd4b578abc5a62dfb3fbb0b0ef02c264513dfb615c5f87871c
+  sha256: 861748c0f9c7d422b32724b114b3817d818ed4eab86c09781aa0a3f7ceabb7f9
   
 build:
   number: 0
@@ -16,8 +16,6 @@ build:
     # d1trimfile option is added by a patch and disabled by unsetting SRC_DIR
     # https://github.com/conda-forge/python-feedstock/blob/e7ea437a819f8f06dcbc3769f6e46dc026070c44/recipe/patches/0021-Add-d1trimfile-SRC_DIR-to-make-pdbs-more-relocatable.patch
     - set "SRC_DIR="   # [win]
-    # unvendor xsimd; use version packaged by conda
-    - {{ PYTHON }} -c "import os, shutil; shutil.rmtree(os.path.join('pythran', 'xsimd'))"
     # on windows, pythran wrongly sets %PREFIX\include instead of %PREFIX%\Library\include;
     # pythran-win32.cfg already exists and has [compiler].include_dirs; we replace it on the fly;
     # conda will detect the written environment-path and replace it as appropriate for user installs;
@@ -51,7 +49,6 @@ requirements:
     - ply >=3.4
     - beniget >=0.4.0,<0.5.0
     - setuptools # used in pythran.dist
-    - xsimd 12.1.1
 
 test:
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,6 +16,10 @@ build:
     # d1trimfile option is added by a patch and disabled by unsetting SRC_DIR
     # https://github.com/conda-forge/python-feedstock/blob/e7ea437a819f8f06dcbc3769f6e46dc026070c44/recipe/patches/0021-Add-d1trimfile-SRC_DIR-to-make-pdbs-more-relocatable.patch
     - set "SRC_DIR="   # [win]
+    # Set compilers to clang-cl
+    - set "CC=clang-cl.exe"  # [win]
+    - set "CXX=clang-cl.exe" # [win]
+    - set "LDFLAGS=" # [win]
     # on windows, pythran wrongly sets %PREFIX\include instead of %PREFIX%\Library\include;
     # pythran-win32.cfg already exists and has [compiler].include_dirs; we replace it on the fly;
     # conda will detect the written environment-path and replace it as appropriate for user installs;
@@ -31,7 +35,7 @@ build:
 
 requirements:
   build:
-    - {{ compiler('cxx') }}  # [not win]
+    - {{ compiler('cxx') }}
     - clang                  # [win]
     - clangxx                # [win]
   host:
@@ -40,7 +44,7 @@ requirements:
     - setuptools
     - wheel
   run:
-    - {{ compiler('cxx') }}  # [not win]
+    - {{ compiler('cxx') }}
     - clang                  # [win]
     - clangxx                # [win]
     - python
@@ -55,17 +59,16 @@ test:
     - pip
     # default to testing openblas
     - openblas-devel {{ openblas }}   # [linux or osx]
-    - {{ compiler('c') }}  # [osx]
   files:
     - dprod.py
     - simple_numexpr.py
   commands:
     - pip check
-    - export CBS="-isysroot $(xcrun --show-sdk-path)" # [osx]
-    - export CFLAGS="${CFLAGS} ${CBS}"  # [osx]
-    - export CXXFLAGS="${CXXFLAGS} ${CBS}"  # [osx]
-    - export LDFLAGS="${LDFLAGS} ${CBS}"  # [osx]
     - set "SRC_DIR="  # [win]
+    # Set compilers to clang-cl
+    - set "CC=clang-cl.exe"  # [win]
+    - set "CXX=clang-cl.exe" # [win]
+    - set "LDFLAGS=" # [win]
     - pythran --version
     - pythran --help
     - pythran-config -vvv


### PR DESCRIPTION
pythran 0.16.1

**Destination channel:** main
### Links

- https://anaconda.atlassian.net/browse/PKG-6014
- https://github.com/serge-sans-paille/pythran/tree/0.16.1
- [[Upstream changelog/diff]()](https://github.com/serge-sans-paille/pythran/blob/0.16.1/Changelog)

### Explanation of changes:

- Keeping xsimd vendored. Rationale: The only package depending on xsimd is pythran. Pythran tend to vendor xsimd at specific commits. xsimd is released with the same license as pythran.
- Make pythran also depend on the compiler on windows. This forces using the activation script to point to the right sdk. We then have to point CC to clang-cl (in the same fashion as what is done in scipy and scikit-image, our two feedstocks using pythran in their build).
